### PR TITLE
Windows build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,6 @@ add_library(${PROJECT_NAME} INTERFACE)
 
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_20)
 
-target_compile_options(${PROJECT_NAME} INTERFACE -Wall -Wextra -Wpedantic)
-
 # Link dependencies
 target_link_libraries(
   ${PROJECT_NAME} INTERFACE function2::function2 RiftenDeque::RiftenDeque ${CMAKE_THREAD_LIBS_INIT}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,11 @@ if(TEST_INSTALLED_VERSION)
   find_package(RiftenThiefpool REQUIRED)
 else()
   CPMAddPackage(NAME RiftenThiefpool SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    target_compile_options(RiftenThiefpool INTERFACE -Wall -Wextra -Wpedantic)
+  elseif(MSVC)
+    target_compile_options(RiftenThiefpool INTERFACE /W4)
+  endif()
 endif()
 
 # ---- Tests ----
@@ -39,6 +44,10 @@ add_executable(${PROJECT_NAME} "${sources}")
 # Link dependencies
 target_link_libraries(
   ${PROJECT_NAME} PUBLIC doctest::doctest RiftenThiefpool::RiftenThiefpool ${CMAKE_THREAD_LIBS_INIT}
+)
+
+target_compile_definitions(
+  ${PROJECT_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:DOCTEST_CONFIG_USE_STD_HEADERS>
 )
 
 enable_testing()

--- a/test/thiefpool_test.cpp
+++ b/test/thiefpool_test.cpp
@@ -1,4 +1,5 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"
 
 #include "riften/thiefpool.hpp"
 
@@ -6,8 +7,6 @@
 #include <iostream>
 #include <thread>
 #include <vector>
-
-#include "doctest/doctest.h"
 
 TEST_CASE("Construct-Destruct") {
     for (std::size_t i = 0; i < 10000; i++) {


### PR DESCRIPTION
Hello! Thanks for this library, it was a great inspiration for my own implementation :) 

I've patched a few issues that show up on Windows when building your library and the unit tests. Let me know your thoughts. Thanks!

## Changes

* Move `target_compile_options` setting of error/warning flags to the test subdirectory so that they're not always set on the header library (and thus passed to consuming libraries/projects). 
* Build fixes when using `doctest` on Windows along with the `DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN` macro.